### PR TITLE
Support scuttlebutt 5.5.20

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,13 +31,13 @@ Authoritee.prototype.onRel = function (key, fn) {
 var applyUpdate = Authoritee.prototype.applyUpdate
 
 Authoritee.prototype.applyUpdate = function (update) {
-  var key = update[0]
-  var changed = update[1]
-
+  var _update = update[0]
+  var key = _update[0]
+  var changed = _update[1]
   var now = Date.now()
   var dt = now - this.last[key]
 
-  if (this.checks[key]) update[1] = this.checks[key](changed, this.get(key), dt)
+  if (this.checks[key]) _update[1] = this.checks[key](changed, this.get(key), dt)
 
   this.last[key] = now
   return applyUpdate.call(this, update)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "authority"
   ],
   "dependencies": {
-    "scuttlebutt": "~4.1.1"
+    "scuttlebutt": "~5.5.20"
   },
   "author": "Julian Gruber <julian@juliangruber.com>",
   "license": "MIT"

--- a/test/absolute.js
+++ b/test/absolute.js
@@ -16,7 +16,9 @@ test('absolute', function () {
   })
 
   var updates = 0
-  m.modelC.on('update', function (key, val) {
+  m.modelC.on('update', function (change, timestamp, source) {
+    var key = change[0]
+    var val = change[1]
     if (key != 'cords') return
 
     updates++

--- a/test/relative.js
+++ b/test/relative.js
@@ -15,7 +15,10 @@ test('relative', function () {
   })
 
   var updates = 0
-  m.modelC.on('update', function (key, val) {
+  m.modelC.on('update', function (change, timestamp, source) {
+    var key = change[0]
+    var val = change[1]
+    
     if (key != 'cords') return
 
     updates++

--- a/test/relay.js
+++ b/test/relay.js
@@ -6,7 +6,9 @@ test('relay', function () {
   var m = mesh()
 
   var called = false
-  m.modelC.on('update', function (key, val) {
+  m.modelC.on('update', function (change, timestamp, source) {
+    var key = change[0]
+    var val = change[1]
     called = true
     assert(key == 'foo')
     assert(val == 'bar')


### PR DESCRIPTION
Support changes on 'update' event arguments (key, value, source
-> change, timestamp, source).

All tests passed. 

I did not bump version, since I don't know whether you use semver or not.
